### PR TITLE
Fixed possible overflow error for large arrays in binary search.

### DIFF
--- a/kernel.txt
+++ b/kernel.txt
@@ -260,7 +260,7 @@ int groups_search(const struct group_info *group_info, gid_t grp)
 
 	while (left < right) {
 
-		unsigned int mid = (left+right)/2;
+		unsigned int mid = left + (right - left)/2;
 
 		if (grp > GROUP_AT(group_info, mid))
 


### PR DESCRIPTION
(left+right)/2 can overflow in the case where, for example, left = 2 and right = 2^(32)-1. In that case, left + (right-left)/2 would not overflow.
