### PR TITLE
set position of access denied and granted to fixed (scrolls with page)

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,7 +37,7 @@ var Typer={
 		return false;
 	},
 	
-	makeAccess:function(){//create Access Granted popUp      FIXME: popup is on top of the page and doesn't show is the page is scrolled
+	makeAccess:function(){//create Access Granted popUp      
 		Typer.hidepop(); // hide all popups
 		Typer.accessCount=0; //reset count
 		var ddiv=$("<div id='gran'>").html(""); // create new blank div and id "gran"
@@ -46,7 +46,7 @@ var Typer={
 		$(document.body).prepend(ddiv); // prepend div to body
 		return false;
 	},
-	makeDenied:function(){//create Access Denied popUp      FIXME: popup is on top of the page and doesn't show is the page is scrolled
+	makeDenied:function(){//create Access Denied popUp      
 		Typer.hidepop(); // hide all popups
 		Typer.deniedCount=0; //reset count
 		var ddiv=$("<div id='deni'>").html(""); // create new blank div and id "deni"

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ body{
 }
 
 .accessGranted{
-	position:absolute;
+	position:fixed;
 	top:200px;
 	background:#333;
 	padding:20px;
@@ -17,7 +17,7 @@ body{
 }
 
 .accessDenied{
-	position:absolute;
+	position:fixed;
 	top:200px;
 	color:#F00;
 	background:#511;


### PR DESCRIPTION
Small CSS tweak so that the position of the access granted and denied boxes are still centered after page scroll
