### PR TITLE
Hide scrollbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,3 +28,5 @@ body{
 	margin-left:-150px;
 	text-align:center;
 }
+
+HTML{ overflow-y: hidden; }


### PR DESCRIPTION
When trying to impress friends with your hacker typing prowess, you can sometimes be foiled by the scrollbar that shows up on the right after the hacker text reaches the next page (like [so](http://i.imgur.com/tVXC6Br.png)).  In order to prevent this from occurring, I have changed a couple lines of code to hide the scrollbar on most browsers.