### PR TITLE
Check for all function keys, instead of just F11. (#12)

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,10 +94,11 @@ var Typer={
       console.html(text.replace(rtn,"<br/>").replace(rtt,"&nbsp;&nbsp;&nbsp;&nbsp;").replace(rts,"&nbsp;"));// replace newline chars with br, tabs with 4 space and blanks with an html blank
 			window.scrollBy(0,50); // scroll to make sure bottom is always visible
 		}
-		if ( key.preventDefault && key.key !== 'F11' ) { // prevent F11(fullscreen) from being blocked
+    var isNotFnKey = !isFunctionKey(key.key);
+		if ( key.preventDefault && isNotFnKey ) { // prevent the function keys from being blocked
 			key.preventDefault()
 		}
-		if(key.key !== 'F11'){ // otherwise prevent keys default behavior
+		if(isNotFnKey){ // otherwise prevent keys default behavior
 			key.returnValue = false;
 		}
 	},
@@ -110,4 +111,19 @@ var Typer={
 		else
 			this.write("|"); // else write it
 	}
+}
+
+// Determine if a key is a function key (F1, F2, etc.)
+function isFunctionKey(key) {
+  if (key.length <= 1)
+    return false;
+  if (key[0] === 'F')
+    return false;
+
+  for (var i = 1; i < key.length; i++) {
+    if (key[i] < '0' || key[i] > '9')
+      return false;
+  }
+
+  return true;
 }


### PR DESCRIPTION
When deciding whether to block a key, check for all function keys. Previously the behaviour was to only check for F11.